### PR TITLE
Postにstatus とview_countの複合インデックスを追加

### DIFF
--- a/db/migrate/20251011125832_add_index_post.rb
+++ b/db/migrate/20251011125832_add_index_post.rb
@@ -1,0 +1,5 @@
+class AddIndexPost < ActiveRecord::Migration[8.0]
+  def change
+    add_index :posts, [ :status, :view_count ], name: "index_posts_on_status_and_view_count"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_10_23_092549) do
+ActiveRecord::Schema[8.0].define(version: 2025_10_11_125832) do
   create_table "comments", force: :cascade do |t|
     t.integer "post_id", null: false
     t.text "body"
@@ -30,6 +30,7 @@ ActiveRecord::Schema[8.0].define(version: 2024_10_23_092549) do
     t.integer "status", default: 0, null: false
     t.integer "view_count", default: 0, null: false
     t.index ["status", "user_id"], name: "index_posts_on_status_and_user_id"
+    t.index ["status", "view_count"], name: "index_posts_on_status_and_view_count"
   end
 
   create_table "posts_tags", id: false, force: :cascade do |t|


### PR DESCRIPTION
```
EXPLAIN QUERY PLAN SELECT "posts".* FROM "posts" WHERE "posts"."status" = 0 ORDER BY "posts"."view_count" DESC LIMIT 5 OFFSET 0;
QUERY PLAN
|--SEARCH posts USING INDEX index_posts_on_status_and_user_id (status=?)
`--USE TEMP B-TREE FOR ORDER BY
```

Index 追加後

```
sqlite> EXPLAIN QUERY PLAN SELECT "posts".* FROM "posts" WHERE "posts"."status" = 0 ORDER BY "posts"."view_count" DESC LIMIT 5 OFFSET 0;
QUERY PLAN
`--SEARCH posts USING INDEX index_posts_on_status_and_view_count (status=?)
sqlite> EXPLAIN QUERY PLAN SELECT COUNT(*) FROM (SELECT 1 AS one FROM "posts" WHERE "posts"."status" = 0
 LIMIT 5 OFFSET 0)
   ...> ;
QUERY PLAN
|--CO-ROUTINE (subquery-1)
|  `--SEARCH posts USING COVERING INDEX index_posts_on_status_and_view_count (status=?)
`--SCAN (subquery-1)
```